### PR TITLE
feat: Wait for network idle instead of number of videos.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "TikTokScraper",
 			"version": "0.0.1",
-			"license": "ISC",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"apify": "^2.0.0",
-				"puppeteer": "*"
+				"puppeteer": "^10.4.0"
 			},
 			"devDependencies": {
 				"@apify/eslint-config": "^0.1.3",
@@ -3978,9 +3979,9 @@
 			}
 		},
 		"node_modules/puppeteer": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.2.0.tgz",
-			"integrity": "sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.4.0.tgz",
+			"integrity": "sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"debug": "4.3.1",
@@ -8267,9 +8268,9 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"puppeteer": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.2.0.tgz",
-			"integrity": "sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.4.0.tgz",
+			"integrity": "sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==",
 			"requires": {
 				"debug": "4.3.1",
 				"devtools-protocol": "0.0.901419",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "This is a boilerplate of an Apify actor.",
 	"dependencies": {
 		"apify": "^2.0.0",
-		"puppeteer": "*"
+		"puppeteer": "^10.4.0"
 	},
 	"devDependencies": {
 		"@apify/eslint-config": "^0.1.3",

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,9 +3,11 @@ const Apify = require('apify');
 const { utils: { log } } = Apify;
 
 exports.handleList = async ({ request, page }, requestQueue) => {
-    // 6 is the initial number of loaded videos, actually after a while there are 36 videos loaded and
-    // this continues with the scroll event - not implemented yet
-    await page.waitForFunction('document.querySelectorAll("main .video-feed-item").length > 6');
+    // Wait for the network to settle, initially there will be 36 videos loaded. There
+    // are more with a scroll event - not implemented yet.
+    await page.waitForNetworkIdle({
+        idleTime: 2000
+    });
     // video-feed list
     const videoUrls = await page.evaluate(() => {
         const result = [];


### PR DESCRIPTION
```js
await page.waitForFunction('document.querySelectorAll("main .video-feed-item").length > 6');
```

There was a problem where some `.video-feed-item` loaded without an `href` in the `a` tag. By waiting for the network to settle the scraping is more consistent, in our tests we see 36 videos found consistently.

Thanks for writing this by the way!